### PR TITLE
refactor: update method to match 5.7 args

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "designmynight"
     ],
     "require": {
-        "illuminate/support": "^5.6",
+        "illuminate/support": "^5.7",
         "laravel/horizon": "^1.4",
         "vladimir-yuldashev/laravel-queue-rabbitmq": "^7.1.1"
     },

--- a/src/RabbitMQQueue.php
+++ b/src/RabbitMQQueue.php
@@ -128,12 +128,13 @@ class RabbitMQQueue extends BaseQueue
      * Create a payload string from the given job and data.
      *
      * @param  string  $job
+     * @param  string  $queue
      * @param  mixed   $data
      * @return string
      */
-    protected function createPayloadArray($job, $data = '')
+    protected function createPayloadArray($job, $queue, $data = '')
     {
-        return array_merge(parent::createPayloadArray($job, $data), [
+        return array_merge(parent::createPayloadArray($job, $queue, $data), [
             'id' => $this->getRandomId(),
             'attempts' => 0,
         ]);


### PR DESCRIPTION
@StevePorter92 this commit to Laravel Framework changed the method signature https://github.com/laravel/framework/commit/3f68cbe3df82990c69e34309901fcefefdb65c95 

I've updated the method in this class and bumped the required version of Illuminate\Support to 5.7