### PR TITLE
Fix RabbitMQJob (#12)

### DIFF
--- a/src/Jobs/RabbitMQJob.php
+++ b/src/Jobs/RabbitMQJob.php
@@ -9,7 +9,7 @@ class RabbitMQJob extends BaseJob
     /**
      * {@inheritdoc}
      */
-    public function delete()
+    public function delete(): void
     {
         parent::delete();
 


### PR DESCRIPTION
Fix for #12 
```
In RabbitMQJob.php line 7:
                                                                               
  Declaration of DesignMyNight\Laravel\Horizon\Jobs\RabbitMQJob::delete() mus  
  t be compatible with VladimirYuldashev\LaravelQueueRabbitMQ\Queue\Jobs\Rabb  
  itMQJob::delete(): void    
```